### PR TITLE
Refactor logic

### DIFF
--- a/src/Logic/Classes.hs
+++ b/src/Logic/Classes.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts      #-}
 
 {-|
   Module      :  Logic.Classes
@@ -30,7 +28,6 @@ module Logic.Classes
 
 import Logic.Proof
 import Theory.Equality
-import Theory.Named
 
 {--------------------------------------------------------
   Special properties of predicates and functions
@@ -46,13 +43,12 @@ import Theory.Named
 
 @
 -- Define a reflexive binary relation
-newtype SameColor p q = SameColor Defn
+data SameColor p q
 instance Reflexive SameColor
 @
--}   
+-}
 class Reflexive r where
   refl :: Proof (r x x)
-  default refl :: (Defining (r x x)) => Proof (r x x)
   refl = axiom
 
 {-| A binary relation R is /symmetric/ if, for all x and y,
@@ -66,13 +62,12 @@ class Reflexive r where
 
 @
 -- Define a symmetric binary relation
-newtype NextTo p q = NextTo Defn
+data NextTo p q
 instance Symmetric NextTo
 @
--}   
+-}
 class Symmetric c where
-  symmetric :: c p q -> Proof (c q p)
-  default symmetric :: (Defining (c p q)) => c p q -> Proof (c q p)
+  symmetric :: Proof (c p q) -> Proof (c q p)
   symmetric _ = axiom
 
 {-| A binary relation R is /transitive/ if, for all x, y, z,
@@ -86,17 +81,16 @@ class Symmetric c where
 
 @
 -- Define a transitive binary relation
-newtype CanReach p q = CanReach Defn
+data CanReach p q
 instance Transitive CanReach
 @
--}   
+-}
 class Transitive c where
-  transitive :: c p q -> c q r -> Proof (c p r)
-  default transitive :: Defining (c p q) => c p q -> c q r -> Proof (c p r)
+  transitive :: Proof (c p q) -> Proof (c q r) -> Proof (c p r)
   transitive _ _ = axiom
 
 -- | @transitive@, with the arguments flipped.
-transitive' :: Transitive c => c q r -> c p q -> Proof (c p r)
+transitive' :: Transitive c => Proof (c q r) -> Proof (c p q) -> Proof (c p r)
 transitive' = flip transitive
 
 {-| A binary operation @#@ is idempotent if @x # x == x@ for all @x@.
@@ -108,15 +102,14 @@ transitive' = flip transitive
 
 @
 -- Define an idempotent binary operation
-newtype Union x y = Union Defn
+data Union x y
 instance Idempotent Union
 @
 -}
 class Idempotent c where
   idempotent :: Proof (c p p == p)
-  default idempotent :: Defining (c p p) => Proof (c p p == p)
   idempotent = axiom
-  
+
 {-| A binary operation @#@ is commutative if @x # y == y # x@ for all @x@ and @y@.
     The @Commutative c@ typeclass provides a single method,
     @commutative :: Proof (c x y == c y x)@.
@@ -126,13 +119,12 @@ class Idempotent c where
 
 @
 -- Define a commutative binary operation
-newtype Union x y = Union Defn
+data Union x y
 instance Commutative Union
 @
 -}
 class Commutative c where
   commutative :: Proof (c p q == c q p)
-  default commutative :: Defining (c p q) => Proof (c p q == c q p)
   commutative = axiom
 
 {-| A binary operation @#@ is associative if @x # (y # z) == (x # y) # z@ for
@@ -145,13 +137,12 @@ class Commutative c where
 
 @
 -- Define an associative binary operation
-newtype Union x y = Union Defn
+data Union x y
 instance Associative Union
 @
 -}
 class Associative c where
   associative :: Proof (c p (c q r) == c (c p q) r)
-  default associative :: Defining (c p q) => Proof (c p (c q r) == c (c p q) r)
   associative = axiom
 
 {-| A binary operation @#@ distributes over @%@ on the left if
@@ -165,14 +156,13 @@ class Associative c where
 
 @
 -- x `Union` (y `Intersect` z) == (x `Union` y) `Intersect` (x `Union` z)
-newtype Union     x y = Union     Defn
-newtype Intersect x y = Intersect Defn
+data Union     x y
+data Intersect x y
 instance DistributiveL Union Intersect
 @
 -}
 class DistributiveL c c' where
   distributiveL :: Proof (c p (c' q r) == c' (c p q) (c p r))
-  default distributiveL :: (Defining (c p q), Defining (c' p q)) => Proof (c p (c' q r) == c' (c p q) (c p r))
   distributiveL = axiom
 
 {-| A binary operation @#@ distributes over @%@ on the right if
@@ -186,14 +176,13 @@ class DistributiveL c c' where
 
 @
 -- (x `Intersect` y) `Union` z == (x `Union` z) `Intersect` (y `Union` z)
-newtype Union     x y = Union     Defn
-newtype Intersect x y = Intersect Defn
+data Union     x y
+data Intersect x y
 instance DistributiveR Union Intersect
 @
 -}
 class DistributiveR c c' where
   distributiveR :: Proof (c (c' p q) r == c' (c p r) (c q r))
-  default distributiveR :: (Defining (c p q), Defining (c' p q)) => Proof (c (c' p q) r == c' (c p r) (c q r))
   distributiveR = axiom
 
 {-| A function @f@ is /injective/ if @f x == f y@ implies @x == y@.
@@ -205,13 +194,12 @@ class DistributiveR c c' where
 
 @
 -- {x} == {y} implies x == y.
-newtype Singleton x = Singleton Defn
+data Singleton x
 instance Injective Singleton
 @
 -}
 class Injective f where
-  elim_inj :: (f x == f y) -> Proof (x == y)
-  default elim_inj :: (Defining (f x), Defining (f y)) => (f x == f y) -> Proof (x == y)
+  elim_inj :: Proof (f x == f y) -> Proof (x == y)
   elim_inj _ = axiom
 
 

--- a/src/Logic/NegClasses.hs
+++ b/src/Logic/NegClasses.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts      #-}
 
 {-|
   Module      :  Logic.NegClasses
@@ -19,8 +16,6 @@ module Logic.NegClasses
 
 import Logic.Proof
 import Logic.Propositional (Not)
-import Theory.Equality
-import Theory.Named
 
 {--------------------------------------------------------
   Special properties of predicates and functions
@@ -42,7 +37,6 @@ instance Irreflexive DifferentColor
 -}
 class Irreflexive r where
   irrefl :: Proof (Not (r x x))
-  default irrefl :: (Defining (r x x)) => Proof (Not (r x x))
   irrefl = axiom
 
 
@@ -60,8 +54,7 @@ class Irreflexive r where
 newtype AncestorOf p q = AncestorOf Defn
 instance Antisymmetric AncestorOf
 @
--}   
+-}
 class Antisymmetric c where
-  antisymmetric :: c p q -> Proof (Not (c q p))
-  default antisymmetric :: Defining (c p q) => c p q -> Proof (Not (c q p))
+  antisymmetric :: Proof (c p q) -> Proof (Not (c q p))
   antisymmetric _ = axiom

--- a/src/Logic/Proof.hs
+++ b/src/Logic/Proof.hs
@@ -11,13 +11,8 @@
 module Logic.Proof
   ( -- * The `Proof` monad
     Proof
-  , (|.), (|$), (|/), (|\), ($$)
-  , given
   , axiom, sorry
   ) where
-
-import Data.Coerce
-import Control.Monad ((>=>))
 
 {--------------------------------------------------
   The `Proof` monad
@@ -75,105 +70,6 @@ instance Applicative Proof where
 instance Monad Proof where
   pf >>= f = QED
 
-{-| This operator is just a specialization of @(>>=)@, but
-    can be used to create nicely delineated chains of
-    derivations within a larger proof. The first statement
-    in the chain should produce a formula; @(|$)@ then
-    pipes this formula into the following derivation rule.
-
-> and2or :: (p && q) -> Proof (p || q)
->
-> and2or pq =  and_elimL pq
->           |$ or_introL
--}
-
-(|$) :: Proof p -> (p -> Proof q) -> Proof q
-(|$) = (>>=)
-
-infixr 7 |$
-
---(|-) :: ((p -> Proof r) -> Proof r) -> (p -> Proof r) -> Proof r
-
-{-| This operator is used to create nicely delineated chains of
-    derivations within a larger proof. If X and Y are two
-    deduction rules, each with a single premise and a single
-    conclusion, and the premise of Y matches the conclusion of X,
-    then @X |. Y@ represents the composition of the two
-    deduction rules.
-
-> and2or :: (p && q) -> Proof (p || q)
->
-> and2or =  and_elimL
->        |. or_introL
--}
-
-(|.) :: (p -> Proof q) -> (q -> Proof r) -> p -> Proof r
-(|.) = (>=>)
-
-infixr 9 |.
-
-{-| The @(|/)@ operator is used to feed the remainder of the proof in
-    as a premise of the first argument.
-
-    A common use-case is with the @Or@-elimination rules @or_elimL@ and
-    @or_elimR@, when one case is trivial. For example, suppose we wanted
-    to prove that @R && (P or (Q and (Q implies P)))@ implies @P@:
-
-@
-my_proof :: r && (p || (q && (q --> p))) -> Proof p
-
-my_proof =
-  do  and_elimR          -- Forget the irrelevant r.
-   |. or_elimL given     -- The first case of the || is immediate;
-   |/ and_elim           -- The rest of the proof handles the second case,
-   |. uncurry impl_elim  --   by unpacking the && and feeding the q into
-                         --   the implication (q --> p).
-@
-
-    The rising @/@ is meant to suggest the bottom half of the proof getting
-    plugged in to the Or-elimination line.
--}
-(|/) :: (p -> (q -> Proof r) -> Proof r) -> (q -> Proof r) -> p -> Proof r
-(|/) = flip
-infixr 9 |/
-
-{-| The @(|\\)@ operator is used to take the subproof so far and feed it
-    into a rule that is expecting a subproof as a premise.
-
-    A common use-case is with the @Not@-introduction rule @not_intro@,
-    which has a type that fits the second argument of @(|\\)@. By way
-    of example, here is a proof that "P implies Q" along with "Not Q"
-    implies "Not P".
-
-@
-my_proof :: (p --> q) -> (Not p --> r) -> Not q -> Proof r
-
-my_proof impl1 impl2 q' =
-  do  modus_ponens impl1   -- This line, composed with the next,
-   |. contradicts' q'      --   form a proof of FALSE from p.
-   |\\ not_intro            -- Closing the subproof above, conclude not-p.
-   |. modus_ponens impl2   -- Now apply the second implication to conclude r.
-@
-
-    The falling @\\@ is meant to suggest the upper half of the proof
-    being closed off by the Not-introduction line.
--}
-(|\) :: (p -> Proof q) -> ((p -> Proof q) -> Proof r) -> Proof r
-(|\) = flip ($)
-infixl 8 |\
-
--- | Take a proof of @p@ and feed it in as the first premise of
---   an argument that expects a @p@ and a @q@.
-($$) :: (p -> q -> Proof r) -> Proof p -> (q -> Proof r)
-(f $$ pp) q = do { p <- pp; f p q }
-
--- | @given@ creates a proof of P, given P as
---   an assumption.
---
---   @given@ is just a specialization of @pure@ / @return@.
-given :: p -> Proof p
-given _ = QED
-
 -- | @sorry@ can be used to provide a "proof" of
 --   any proposition, by simply assering it as
 --   true. This is useful for stubbing out portions
@@ -200,4 +96,3 @@ rev_length_lemma = axiom
 -}
 axiom :: Proof p
 axiom = QED
-

--- a/src/Logic/Proof.hs
+++ b/src/Logic/Proof.hs
@@ -9,38 +9,35 @@
 -}
 
 module Logic.Proof
-  ( -- * The `Proof` monad
+  ( -- * The `Proof` type
     Proof
   , axiom, sorry
   ) where
 
 {--------------------------------------------------
-  The `Proof` monad
+  The `Proof` type
 --------------------------------------------------}
 
-{-| The @Proof@ monad is used as a domain-specific
+{-| The @Proof@ type is used as a domain-specific
     language for constructing proofs. A value of type
     @Proof p@ represents a proof of the proposition @p@.
 
-    For example, this function constructions a proof of
-    "P or Q" from the assumption "P and Q":
+    A @Proof@ as an argument to a function represents an
+    assumption. For example, this function constructions a proof of "P
+    or Q" from the assumption "P and Q":
 
-> and2or :: (p && q) -> Proof (p || q)
+> and2or :: Proof (p && q) -> Proof (p || q)
 >
-> and2or pq = do
->    p <- and_elimL pq    -- or: "p <- fst <$> and_elim pq"
->    or_introL p
+> and2or pq = introOrL $ elimAndL pq
 
     If the body of the proof does not match the proposition
     you claim to be proving, the compiler will raise a type
     error. Here, we accidentally try to use @or_introR@
     instead of @or_introL@:
 
-> and2or :: (p && q) -> Proof (p || q)
+> and2or :: Proof (p && q) -> Proof (p || q)
 >
-> and2or pq = do
->    p <- and_elimL pq
->    or_introR p
+> and2or pq = introOrR $ elimAndL pq
 
 resulting in the error
 
@@ -48,27 +45,17 @@ resulting in the error
     • Couldn't match type ‘p’ with ‘q’
       ‘p’ is a rigid type variable bound by
         the type signature for:
-          and2or :: forall p q. (p && q) -> Proof (p || q)
+          and2or :: forall p q. Proof (p && q) -> Proof (p || q)
 
       ‘q’ is a rigid type variable bound by
         the type signature for:
-          and2or :: forall p q. (p && q) -> Proof (p || q)
+          and2or :: forall p q. Proof (p && q) -> Proof (p || q)
 
       Expected type: Proof (p || q)
         Actual type: Proof (p || p)
 @
 -}
 data Proof (pf :: *) = QED
-
-instance Functor Proof where
-  fmap _ = const QED -- modus ponens (external?)
-
-instance Applicative Proof where
-  pure = const QED -- axiom
-  pf1 <*> pf2 = QED -- modus ponens (internal?)
-
-instance Monad Proof where
-  pf >>= f = QED
 
 -- | @sorry@ can be used to provide a "proof" of
 --   any proposition, by simply assering it as

--- a/src/Logic/Proof.hs
+++ b/src/Logic/Proof.hs
@@ -79,8 +79,8 @@ sorry = QED
 data Reverse xs = Reverse Defn
 data Length  xs = Length  Defn
 
-rev_length_lemma :: Proof (Length (Reverse xs) == Length xs)
-rev_length_lemma = axiom
+revLengthLemma :: Proof (Length (Reverse xs) == Length xs)
+revLengthLemma = axiom
 @
 -}
 axiom :: Proof p

--- a/src/Logic/Proof.hs
+++ b/src/Logic/Proof.hs
@@ -79,6 +79,7 @@ instance Monad Proof where
 -- _Completed proofs should never use @sorry@!_
 sorry :: Proof p
 sorry = QED
+{-# WARNING sorry "Completed proofs should never use sorry!" #-}
 
 {-| @axiom@, like @sorry@, provides a "proof" of any
     proposition. Unlike @sorry@, which is used to indicate

--- a/src/Logic/Proof.hs
+++ b/src/Logic/Proof.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds      #-}
 
 {-|
   Module      :  Logic.Proof
@@ -55,7 +56,7 @@ resulting in the error
         Actual type: Proof (p || p)
 @
 -}
-data Proof (pf :: *) = QED
+data Proof (pf :: k) = QED
 
 -- | @sorry@ can be used to provide a "proof" of
 --   any proposition, by simply assering it as

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -102,28 +102,28 @@ import Theory.Named
 --------------------------------------------------}
 
 -- | The constant "true".
-newtype TRUE  = TRUE Defn
+data TRUE
 
 -- | The constant "false".
-newtype FALSE = FALSE Defn
+data FALSE
 
 -- | The conjunction of @p@ and @q@.
-newtype And p q = And Defn
+data And p q
 
 -- | The disjunction of @p@ and @q@.
-newtype Or p q  = Or  Defn
+data Or p q
 
 -- | The negation of @p@.
-newtype Not p   = Not Defn
+data Not p
 
 -- | The implication "@p@ implies @q@".
-newtype Implies p q = Implies Defn
+data Implies p q
 
 -- | Existential quantifiation.
-newtype Exists x p = Exists Defn
+data Exists x p
 
 -- | Universal quantification.
-newtype ForAll x p = ForAll Defn
+data ForAll x p
 
 -- | An infix alias for @Or@.
 type p || q   = p `Or` q

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE ExplicitNamespaces    #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE TypeOperators         #-}
 
 {-|
   Module      :  Logic.Propositional

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -335,7 +335,7 @@ modus_ponens = flip impl_elim
                                   -----         (assumption)
                         p --> q,    p
                        ---------------------    (modus ponens)
-                 q,           Not q
+               Not q,            q
               --------------------------        (contradicts')
                       FALSE
           ------------------------------------- (not-intro)

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -76,26 +76,28 @@ module Logic.Propositional
   , contradiction
   , not_not_elim
 
-   -- *** Mapping over conjunctions and disjunctions
-  , and_mapL
-  , and_mapR
-  , and_map
+  -- *** Mapping over conjunctions and disjunctions.
 
-  , or_mapL
-  , or_mapR
-  , or_map
+  -- | These function names mimic the ones for @Bifunctor@ and
+  -- @Profunctor@.
+  , firstAnd
+  , secondAnd
+  , bimapAnd
 
-  , impl_mapL
-  , impl_mapR
-  , impl_map
+  , firstOr
+  , secondOr
+  , bimapOr
 
-  , not_map
+  , lmapImpl
+  , rmapImpl
+  , dimapImpl
+
+  , mapNot
 
   ) where
 
 import Logic.Classes
 import Logic.Proof
-import Theory.Named
 
 {--------------------------------------------------
   Logical constants
@@ -164,54 +166,48 @@ infixr 1 -->
 --------------------------------------------------}
 
 -- | Apply a derivation to the left side of a conjunction.
-and_mapL :: (Proof p -> Proof p') -> Proof (p && q) -> Proof (p' && q)
-and_mapL impl conj = let
-  (lhs, rhs) = and_elim conj
-  lhs' = impl lhs
-  in and_intro lhs' rhs
+firstAnd :: (Proof p -> Proof p') -> Proof (p && q) -> Proof (p' && q)
+firstAnd = flip bimapAnd id
 
 -- | Apply a derivation to the right side of a conjunction.
-and_mapR :: (Proof q -> Proof q') -> Proof (p && q) -> Proof (p && q')
-and_mapR impl conj = let
-  (lhs, rhs) = and_elim conj
-  rhs' = impl rhs
-  in and_intro lhs rhs'
+secondAnd :: (Proof q -> Proof q') -> Proof (p && q) -> Proof (p && q')
+secondAnd = bimapAnd id
 
 -- | Apply derivations to the left and right sides of a conjunction.
-and_map :: (Proof p -> Proof p') -> (Proof q -> Proof q') -> Proof (p && q) -> Proof (p' && q')
-and_map implP implQ conj = let
+bimapAnd :: (Proof p -> Proof p') -> (Proof q -> Proof q') -> Proof (p && q) -> Proof (p' && q')
+bimapAnd implP implQ conj = let
   (lhs, rhs) = and_elim conj
   lhs' = implP lhs
   rhs' = implQ rhs
   in and_intro lhs' rhs'
 
 -- | Apply a derivation to the left side of a disjunction.
-or_mapL :: (Proof p -> Proof p') -> Proof (p || q) -> Proof (p' || q)
-or_mapL impl = or_elim (or_introL . impl) or_introR
+firstOr :: (Proof p -> Proof p') -> Proof (p || q) -> Proof (p' || q)
+firstOr = flip bimapOr id
 
 -- | Apply a derivation to the right side of a disjunction.
-or_mapR :: (Proof q -> Proof q') -> Proof (p || q) -> Proof (p || q')
-or_mapR impl = or_elim or_introL (or_introR . impl)
+secondOr :: (Proof q -> Proof q') -> Proof (p || q) -> Proof (p || q')
+secondOr = bimapOr id
 
 -- | Apply derivations to the left and right sides of a disjunction.
-or_map :: (Proof p -> Proof p') -> (Proof q -> Proof q') -> Proof (p || q) -> Proof (p' || q')
-or_map implP implQ = or_elim (or_introL . implP) (or_introR . implQ)
+bimapOr :: (Proof p -> Proof p') -> (Proof q -> Proof q') -> Proof (p || q) -> Proof (p' || q')
+bimapOr implP implQ = or_elim (or_introL . implP) (or_introR . implQ)
 
 -- | Apply a derivation to the left side of an implication.
-impl_mapL :: (Proof p' -> Proof p) -> Proof (p --> q) -> Proof (p' --> q)
-impl_mapL derv impl = impl_intro (modus_ponens impl . derv)
+lmapImpl :: (Proof p' -> Proof p) -> Proof (p --> q) -> Proof (p' --> q)
+lmapImpl = flip dimapImpl id
 
 -- | Apply a derivation to the right side of an implication.
-impl_mapR :: (Proof q -> Proof q') -> Proof (p --> q) -> Proof (p --> q')
-impl_mapR derv impl = impl_intro (derv . modus_ponens impl)
+rmapImpl :: (Proof q -> Proof q') -> Proof (p --> q) -> Proof (p --> q')
+rmapImpl = dimapImpl id
 
 -- | Apply derivations to the left and right sides of an implication.
-impl_map :: (Proof p' -> Proof p) -> (Proof q -> Proof q') -> Proof (p --> q) -> Proof (p' --> q')
-impl_map dervL dervR impl = impl_intro (dervR . modus_ponens impl . dervL)
+dimapImpl :: (Proof p' -> Proof p) -> (Proof q -> Proof q') -> Proof (p --> q) -> Proof (p' --> q')
+dimapImpl dervL dervR impl = impl_intro (dervR . modus_ponens impl . dervL)
 
 -- | Apply a derivation inside of a negation.
-not_map :: (Proof p' -> Proof p) -> Proof (Not p) -> Proof (Not p')
-not_map impl notP = not_intro (absurd . contradicts' notP . impl)
+mapNot :: (Proof p' -> Proof p) -> Proof (Not p) -> Proof (Not p')
+mapNot impl notP = not_intro (absurd . contradicts' notP . impl)
 
 {--------------------------------------------------
   Tautologies

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -24,7 +22,7 @@ module Logic.Propositional
 
   -- ** Logical symbols
     TRUE, FALSE
-  
+
   , And,     type (&&), type (∧), type (/\)
   , Or,      type (||), type (∨), type (\/)
   , Implies, type (-->)
@@ -94,9 +92,6 @@ module Logic.Propositional
 
   ) where
 
-import Data.Arguments
-import Data.Refined
-import Data.The
 import Logic.Classes
 import Logic.Proof
 import Theory.Named
@@ -301,7 +296,7 @@ and_elimR _ = axiom
 --   of P, and a proof of Q.
 and_elim :: p && q -> Proof (p, q)
 and_elim c = (,) <$> and_elimL c <*> and_elimR c
-  
+
 {-| If you have a proof of R from P, and a proof of
      R from Q, then convert "P or Q" into a proof of R.
 -}
@@ -339,7 +334,7 @@ modus_ponens = flip impl_elim
                                   -----         (assumption)
                         p --> q,    p
                        ---------------------    (modus ponens)
-                 q,           Not q    
+                 q,           Not q
               --------------------------        (contradicts')
                       FALSE
           ------------------------------------- (not-intro)
@@ -409,7 +404,7 @@ lem = axiom
 {-| Proof by contradiction: this proof technique allows
      you to prove P by showing that, from "Not P", you
      can prove a falsehood.
-  
+
      Proof by contradiction is not a theorem of
      constructive logic, so it requires the @Classical@
      constraint. But note that the similar technique
@@ -442,7 +437,7 @@ contradiction impl =
    |$ or_elimL given
    |/ impl
    |. absurd
-  
+
 {-| Double-negation elimination. This is another non-constructive
     proof technique, so it requires the @Classical@ constraint.
 
@@ -475,4 +470,3 @@ instance DistributiveL And And
 instance DistributiveL And Or
 instance DistributiveL Or  And
 instance DistributiveL Or  Or
-

--- a/src/Logic/Propositional.hs
+++ b/src/Logic/Propositional.hs
@@ -334,8 +334,8 @@ modusPonens = flip elimImpl
                              Not p
 @
 
-We can encode this proof tree more-or-less directly as a @Proof@
-to implement @modus_tollens@:
+We can encode this proof tree as a @Proof@ to implement
+@modus_tollens@:
 
 @
 modusTollens :: Proof (p --> q) -> Proof (Not q) -> Proof (Not p)


### PR DESCRIPTION
Sorry this took so long. It got a bit bigger than I intended. I'm happy to split it into smaller PRs if there are bits you don't want, or want to take in smaller chunks.

Summary of changes:

* Valuable: I stand by these and really want them merged
  - Use `Proof a` instead of `a` in premises. This makes proof types phantom everywhere.
  - Remove data constructors for logic constants and connectives. Because they are always phantom in `Proof a`, we don't need them.
  - Remove default signatures on the typeclasses for algebraic properties (e.g., `Reflexive`). Because these always take and return proofs, we can make them `axiom` everywhere.
  - Make the `Proof` type poly-kinded. So if someone wants to define his or her logic using `-XDataKinds`, it's possible to use that in a `Proof`.
  - Remove `Functor/Applicative/Monad` instance and custom operators for `Proof`, because they don't make logical sense any more.
  - Made calls to `sorry` emit warnings.
* Semi-valuable: I'd like these merged but am not going to lose sleep.
  - Renamed mapping functions to mimic the ones defined by `Functor`/`Bifunctor`/`Profunctor`.
* Bikeshedding: Happy to drop these on the floor to get the other things in.
  - Renamed functions in `Propositional.hs` to `camelCase`, to make hlint calm down.

Other remarks:
* I couldn't implement an isomorphism between `Proof (a || b)` and `Either (Proof a) (Proof b)`, because you can't tell which of `a` or `b` is true, which is how you select which data constructor to use.
* I couldn't create `Functor`/`Bifunctor`/`Profunctor` instances for the logic types, because to map over a conjunction, say, you need a `Proof p -> Proof p'`, not a `p -> p'`. There might be a typeclass that allows this, but I don't know of one.

Closes #2.