### PR TITLE
Fix Logic.Implicit.on haddock format

### DIFF
--- a/src/Logic/Implicit.hs
+++ b/src/Logic/Implicit.hs
@@ -49,6 +49,7 @@ revConsLemma :: Proof (IsCons xs) -> Proof (IsCons (Reverse xs))
 -- Implement a safe 'last' function.
 last :: Fact (IsCons xs) => ([a] ~~ xs) -> a
 last xs = note (revConsLemma `on` xs) $ head (reverse xs)
+@
 -}
 on :: Fact (p n) => (Proof (p n) -> Proof q) -> (a ~~ n) -> Proof q
 on impl _ = impl known


### PR DESCRIPTION
Hey team- just noticed a missing `@` in the haddock string for `Logic.Implicit.on`, leading to some wonky formatting in the online docs.